### PR TITLE
Update apiVersion for Deployments

### DIFF
--- a/kubernetes/deployment-with-secret.yml
+++ b/kubernetes/deployment-with-secret.yml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-world-app
@@ -8,6 +8,9 @@ metadata:
     app: hello-world-app
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-app
   template:
     metadata:
       labels:

--- a/kubernetes/deployment.yml
+++ b/kubernetes/deployment.yml
@@ -1,6 +1,6 @@
 
 ---
-apiVersion: extensions/v1beta1
+apiVersion: apps/v1
 kind: Deployment
 metadata:
   name: hello-world-app
@@ -8,6 +8,9 @@ metadata:
     app: hello-world-app
 spec:
   replicas: 1
+  selector:
+    matchLabels:
+      app: hello-world-app
   template:
     metadata:
       labels:


### PR DESCRIPTION
extensions/v1beta1 is no longer a valid apiVersion for Kubernetes >=
v1.16. The correct apiVersion to set is apps/v1 that has been available
since version v1.9.

More info: https://kubernetes.io/blog/2019/07/18/api-deprecations-in-1-16/

After this commit the Deployments under kubernetes can no longer be
created without modification on clusters that are older than v1.9.